### PR TITLE
config: make content page wider, wrap text in rhs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /.vitepress/cache/
 /.vitepress/dist/
+public/.DS_Store

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -11,7 +11,24 @@
             #47caff 50%
     );
     --vp-home-hero-image-filter: blur(44px);
+    
+    /* Increase the main content area width */
+    --vp-layout-max-width: 1600px;
 }
+
+
+.VPDoc:not(.has-sidebar) .container {
+  max-width: 1584px !important;
+}
+
+.VPDoc:not(.has-sidebar) .content {
+  max-width: 1264px !important;
+}
+
+.VPDoc.has-aside .content-container {
+  max-width: 1168px !important;
+}
+
 
 @media (min-width: 640px) {
     :root {
@@ -34,4 +51,10 @@
 img[src='/search.png'] {
     width: 100%;
     aspect-ratio: 1 / 1;
+}
+
+
+/* Wrap the text in the right-hand sidebar */
+.VPDocAsideOutline .outline-link {
+    white-space: normal !important;
 }


### PR DESCRIPTION
tried to make space for images and ensure that the rhs wraps text as not to cut off larger titles

example
<img width="1680" height="1989" alt="image" src="https://github.com/user-attachments/assets/d782e0ba-e49d-4492-9f20-6631198fa03b" />


I got the idea from https://llm-jp.github.io/awesome-japanese-llm/en/
See: 
https://github.com/vuejs/vitepress/discussions/1646#discussioncomment-11486171