### PR TITLE
fix: adjust version in getting started for `0.2.0`

### DIFF
--- a/getting-started/quick-start.md
+++ b/getting-started/quick-start.md
@@ -11,7 +11,7 @@ Track progress and upcoming improvements on our [project dashboard](https://gith
 ```bash
 git clone https://github.com/platform-mesh/helm-charts.git
 cd helm-charts
-git checkout v0.2.0
+git checkout 0.2.0
 cd local-setup
 ```
 


### PR DESCRIPTION
The [Getting-Started guide (Clone the repository)](https://platform-mesh.io/main/getting-started/quick-start.html#_1-clone-the-repository) points to the tag `v0.2.0` but it does not exist:

```text
$> git clone https://github.com/platform-mesh/helm-charts.git
cd helm-charts
git checkout v0.2.0
cd local-setup
Cloning into 'helm-charts'...
remote: Enumerating objects: 28436, done.
...
Resolving deltas: 100% (20547/20547), done.
error: pathspec 'v0.2.0' did not match any file(s) known to git
```

The [list of tags](https://github.com/platform-mesh/helm-charts/tags) shows that `0.2.0` or `v0.3.0` exists.

Maybe instead of this PR, you might also create a new tag `v0.2.0`


