### PR TITLE
chore: enable daily Renovate lock file maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>platform-mesh/.github:renovate-config"
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,6 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 5am on monday"]
+    "schedule": ["before 5am every day"]
   }
 }


### PR DESCRIPTION
## Summary

- Enables Renovate lock file maintenance on a daily schedule (before 5am)
- Renovate will recreate the lockfile from scratch, pulling in latest compatible transitive dependency versions
- This ensures transitive security fixes are picked up automatically, even when direct dependencies haven't released a new version