### PR TITLE
Add OpenSSF Scorecard schedule

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -1,0 +1,18 @@
+name: OpenSSF Scorecard
+on:
+    push:
+        branches: [main]
+    schedule:
+        - cron: '30 4 * * 1'
+    workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+    scorecard:
+        uses: platform-mesh/.github/.github/workflows/job-ossf-scorecard.yml@main
+        permissions:
+            security-events: write
+            id-token: write
+            contents: read
+            actions: read

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Platform Mesh Website
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/platform-mesh/platform-mesh.github.io/badge)](https://scorecard.dev/viewer/?uri=github.com/platform-mesh/platform-mesh.github.io)
+
 This is the repository backing the website of the Platform Mesh project.
 
 ## Contributing


### PR DESCRIPTION
Releates to https://github.com/platform-mesh/backlog/issues/227

Enables the OpenSSF Scorecard by calling a schedule workflow every monday at 4:30 AM.
Seperate Pipeline because the Scorecard should only run by pushes on main and scheduled.