### PR TITLE
docs(concepts): add Security architecture section (rework of #114)

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,5 +1,6 @@
 import { withMermaid } from "vitepress-plugin-mermaid";
 import { fileURLToPath, URL } from 'node:url'
+import markdownItFootnote from 'markdown-it-footnote'
 
 // Base path is required because GitHub Pages serves multiple doc versions from subdirectories:
 //   - https://platform-mesh.github.io/main/          (main branch docs)
@@ -146,6 +147,14 @@ export default withMermaid({
             ]
         },
         {
+            text: 'Security architecture',
+            items: [
+            { text: 'Overview', link: '/concepts/security/' },
+            { text: 'Authentication', link: '/concepts/security/authentication' },
+            { text: 'Authorization', link: '/concepts/security/authorization' },
+            ]
+        },
+        {
             text: 'API and integration',
             items: [
             { text: 'API sharing', link: '/concepts/api-sharing' },
@@ -225,6 +234,12 @@ export default withMermaid({
       { icon: 'github', link: 'https://github.com/platform-mesh' }
     ]
 
+  },
+
+  markdown: {
+    config: (md) => {
+      md.use(markdownItFootnote)
+    }
   },
 
 })

--- a/concepts/identity-and-authorization.md
+++ b/concepts/identity-and-authorization.md
@@ -43,6 +43,7 @@ For the actual `AuthorizationConfiguration` YAML, the webhook deployment args, a
 
 ## Related
 
+- [Security architecture](/concepts/security/) — design view: separation of concerns, OIDC federation, ReBAC, account-model integration
 - [Account model](./account-model.md)
 - [IAM Store resource](/reference/resources/iamstore-resource.md)
 - [Keycloak](/reference/components/keycloak.md)

--- a/concepts/security/authentication.md
+++ b/concepts/security/authentication.md
@@ -1,0 +1,41 @@
+# Authentication
+
+Authentication in Platform Mesh establishes a verified identity for every interaction, whether initiated by a human user, an automated pipeline, or a service-to-service call.
+The platform standardizes on **OpenID Connect (OIDC)** as the primary authentication protocol, providing a consistent, token-based identity layer across all participants in the mesh.
+In addition, [kcp](https://kcp.io) natively supports Kubernetes service accounts, enabling workloads and automation to authenticate directly without requiring an external identity provider.
+
+Keycloak is configured as an OIDC provider through [kcp](https://kcp.io)'s **authentication configuration** mechanism, the same declarative approach used to configure any OIDC-compatible identity provider.
+For user-facing identity providers, Keycloak acts as the federation layer through its identity brokering mechanism.
+For machine identity issuers, such as Kubernetes cluster JWT issuers or GitHub Actions OIDC, where identity brokering through Keycloak does not apply, [kcp](https://kcp.io)'s support for OIDC configuration at the workspace level enables direct integration at the account level.
+This ensures that the authentication layer is not hardwired to a single provider or federation path but rather configured through standard Kubernetes primitives.
+
+## Internal identity provider
+
+Keycloak[^1] serves as the internal Identity Provider (IDP) within Platform Mesh.
+As a centralized identity and access management solution implementing OIDC, OAuth 2.0, and SAML 2.0, Keycloak provides the authentication surface through which all platform interactions are verified.
+
+Key aspects of Keycloak's role within Platform Mesh:
+
+- **Token-based identity:** Keycloak issues JWT-based access tokens, ID tokens, and refresh tokens following OIDC standards. These tokens carry identity claims that downstream services consume to establish the caller's identity without repeated authentication.
+- **Authentication flows:** Platform Mesh leverages Keycloak's support for standard OIDC flows — the portal uses interactive browser sessions, while `kubectl` uses a public-client flow with PKCE. See the [Keycloak reference](/reference/components/keycloak) for grant types and protocol specifics.
+- **Tenant-aligned realms:** Platform Mesh creates a dedicated Keycloak realm per organization, providing isolated user stores, client configurations, and authentication policies that align with the hierarchical [account model](/concepts/account-model).
+
+## Identity federation
+
+A critical requirement for any platform operating across organizational boundaries is the ability to integrate with existing identity infrastructure.
+Platform Mesh supports connecting multiple OpenID Connect-compatible identity providers, allowing organizations to integrate with their existing identity infrastructure.
+
+Keycloak addresses this through its identity brokering mechanism.
+External identity providers (corporate OIDC providers, SAML identity providers, LDAP directories) can be connected as federated sources.
+Users authenticate against their existing corporate IDP, and Keycloak translates the external identity into a consistent internal representation, ensuring that downstream authorization decisions operate on a normalized identity regardless of the authentication source.
+
+This approach enables the "bring your own IDP" model essential for multi-organizational service ecosystems while maintaining a uniform authentication contract across the mesh.
+
+## Related
+
+- [Security architecture overview](./)
+- [Authorization](./authorization) — what the established identity is allowed to do
+- [Identity and authorization](/concepts/identity-and-authorization) — runtime view of the authorizer chain
+- [Keycloak](/reference/components/keycloak) — reference for the identity provider component
+
+[^1]: [Keycloak](https://www.keycloak.org/)

--- a/concepts/security/authorization.md
+++ b/concepts/security/authorization.md
@@ -1,0 +1,47 @@
+# Authorization
+
+Once an identity is established, Platform Mesh must determine what that identity is permitted to do.
+Given the complexity of interactions across hierarchical accounts, [service providers](/concepts/personas/service-provider), and [service consumers](/concepts/personas/service-consumer), Platform Mesh supports a **two-tier authorization model**: Kubernetes RBAC for control-plane-local decisions and OpenFGA for authorization across control plane boundaries.
+
+## Kubernetes-native RBAC
+
+The first tier leverages the built-in Role-Based Access Control[^1] mechanism of Kubernetes.
+Since the Platform Mesh API layer is built on the [Kubernetes Resource Model](/concepts/control-planes) and powered by [kcp](https://kcp.io), RBAC is the natural structural access control layer.
+
+Kubernetes RBAC operates at the API resource level, governing which subjects (users, groups, service accounts) can perform which verbs (get, list, create, update, delete) on which resource types within a given workspace.
+Each account functions as an isolated [control plane](/concepts/control-planes) with its own RBAC configuration, meaning access policies are always scoped to the control plane they are defined in.
+RBAC rules are themselves Kubernetes resources, managed declaratively through the same KRM patterns used for all platform resources, consistent with the [declarative API principle](/concepts/why-platform-mesh).
+This extends naturally to Custom Resource Definitions introduced by [Managed Service Providers](/concepts/personas/service-provider): when a service provider exposes new capabilities, the existing RBAC mechanism governs access without additional configuration.
+
+## Fine-grained authorization with ReBAC
+
+The second tier addresses authorization decisions that go beyond what RBAC can express: decisions that depend on relationships between entities such as team memberships, resource ownership, or service subscriptions.
+
+OpenFGA[^2] provides **Relationship-Based Access Control (ReBAC)**, an authorization model based on the Zanzibar approach[^3], where access decisions are derived from a graph of relationships rather than static role assignments.
+Authorization state is expressed as relationship tuples, (user, relation, object), and permissions propagate through the graph.
+For example, if a team has ordered a service and a user is a member of that team, the user inherits access to that service instance without explicit per-user permission grants.
+
+The hierarchical [account model](/concepts/account-model) maps naturally to this relationship graph, and permissions defined at a parent account can flow to child accounts through relationship inheritance.
+Resources from different [service providers](/concepts/personas/service-provider) are represented as distinct resource types in [kcp](https://kcp.io), and access to each is evaluated through the standard SubjectAccessReview mechanism regardless of the provider origin.
+
+## Layered evaluation
+
+Kubernetes RBAC serves as the first gate, enforcing structural access at the API level.
+When RBAC can make a definitive decision (granting or denying access based on resource-type permissions), the request is resolved immediately.
+When RBAC has no opinion, typically for fine-grained access decisions that depend on relationships rather than resource types, the request is forwarded to OpenFGA through the authorization webhook for relationship-based evaluation.
+
+OpenFGA is integrated through [kcp](https://kcp.io)'s standard **authorization webhook** mechanism.
+This means that OpenFGA is not a hardwired component: any authorizer conforming to the Kubernetes authorization webhook interface can be configured as an alternative or additional authorization backend, preserving the platform's commitment to pluggability and decoupling.
+
+## Related
+
+- [Security architecture overview](./)
+- [Authentication](./authentication) — how identity is established before authorization runs
+- [Identity and authorization](/concepts/identity-and-authorization) — runtime view of the authorizer chain
+- [OpenFGA](/reference/components/openfga) — reference for the authorization engine component
+- [rebac-authz-webhook](/reference/components/rebac-authz-webhook) — reference for the kcp ↔ OpenFGA bridge
+- [kcp identity and authorization](/reference/components/kcp/identity-and-authorization) — reference for the AuthorizationConfiguration YAML and webhook deployment
+
+[^1]: [Kubernetes RBAC Documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+[^2]: [OpenFGA](https://openfga.dev/)
+[^3]: [Zanzibar: Google's Consistent, Global Authorization System](https://research.google/pubs/zanzibar-googles-consistent-global-authorization-system/)

--- a/concepts/security/index.md
+++ b/concepts/security/index.md
@@ -1,0 +1,89 @@
+# Security architecture
+
+Securing a distributed, multi-tenant platform that spans organizational boundaries requires a deliberate architectural approach.
+Traditional monolithic security models, where authentication and authorization are tightly coupled within a single system, fail to address the dynamic nature of service ecosystems where [service providers](/concepts/personas/service-provider), [service consumers](/concepts/personas/service-consumer), and marketplace operators interact across isolated [control planes](/concepts/control-planes).
+
+Platform Mesh addresses this challenge through a clear separation of authentication and authorization as independent architectural concerns, each implemented by purpose-built components that can evolve, scale, and be replaced independently.
+This design aligns directly with the [decoupling principle](/concepts/why-platform-mesh) that guides the overall architecture: security subsystems, like all other components, should be directly usable without requiring the complete framework.
+
+For the runtime view — which component plays which role and how requests pass through the authorizer chain — see [Identity and authorization](/concepts/identity-and-authorization).
+
+## Client entry paths
+
+Platform Mesh is accessed through multiple client types, each with distinct interaction patterns.
+UI clients interact through a Kubernetes-GraphQL-Gateway, `kubectl` users communicate directly with [kcp](https://kcp.io) via the KRM API, and AI agents are expected to interact through a dedicated MCP (Model Context Protocol) server[^1].
+Regardless of the client type, all requests ultimately reach kcp, where the same authentication and authorization mechanisms apply uniformly.
+
+[^1]: The MCP server for Platform Mesh is a planned future component.
+
+```mermaid
+flowchart LR
+    UI[UI Client] --> GW[GraphQL Gateway]
+    CLI[kubectl] --> KCP
+    GW --> KCP[kcp]
+    AI[AI Client] -.-> MCP["MCP Server (planned)"]
+    MCP -.-> KCP
+
+    style MCP stroke-dasharray: 5 5
+    style AI stroke-dasharray: 5 5
+```
+
+## Authentication and authorization flow
+
+Once a request reaches kcp, the authentication configuration establishes the caller's identity, and a layered authorizer chain decides whether the request is allowed.
+RBAC handles structural, resource-type access; the authorization webhook forwards anything RBAC has no opinion on to OpenFGA for relationship-based evaluation.
+
+```mermaid
+flowchart TD
+    KCP[kcp] --> AUTHN[AuthN Config]
+    AUTHN -->|OIDC| KC[Keycloak]
+    AUTHN --> SA[ServiceAccounts]
+    KC -->|identity established| RBAC[RBAC]
+    SA -->|identity established| RBAC
+    RBAC -->|granted| RES[Access Granted]
+    RBAC -->|denied| DENY[Access Denied]
+    RBAC -->|no opinion| WH[AuthZ Webhook]
+    WH -->|check| FGA[OpenFGA]
+    FGA -->|granted| RES
+    FGA -->|denied| DENY
+```
+
+## Separation of concerns
+
+[Authentication](./authentication) and [authorization](./authorization) are independent subsystems, reflecting Platform Mesh [guiding principles](/concepts/why-platform-mesh).
+The two are connected solely through the OIDC token: authentication produces it, authorization consumes the identity claims within it.
+While OIDC tokens carry claims such as group memberships that inform RBAC decisions, the token should establish _who_ the caller is, not _what_ they are allowed to do — encoding permissions as group claims is an anti-pattern that blurs this boundary.
+They share no other state, meaning each can evolve, scale, and be replaced independently.
+Both are integrated through standard Kubernetes extension points (authentication configurations for identity providers and authorization webhooks for authorizers), enabling alternative implementations that satisfy the same interfaces.
+
+However, Platform Mesh provides specific integration with Keycloak and OpenFGA, such as per-organization realm and store provisioning, identity brokering configuration, and dynamic authorization schema generation.
+Replacing either component with an alternative would require reimplementing these integration aspects.
+
+:::info NOTE
+Platform Mesh security architecture represents ongoing research in distributed authorization patterns.
+The model continues to evolve to support enhanced cross-provider authorization scenarios, relationship-based authorization model management, and advanced authorization propagation across the account hierarchy.
+:::
+
+Platform Mesh security architecture builds on [kcp](https://kcp.io)'s own security foundations, including workspace isolation, APIExport identity, and permission claims.
+For a detailed analysis of these foundations, see the [kcp Security Self-Assessment](https://docs.kcp.io/kcp/v0.30/contributing/governance/security-self-assessment/) (particularly the [Security Functions and Features](https://docs.kcp.io/kcp/v0.30/contributing/governance/security-self-assessment/#security-functions-and-features) section) and the [security section of kcp's General Technical Review](https://docs.kcp.io/kcp/v0.30/contributing/governance/general-technical-review/#security).
+
+## Security and the account model
+
+The security architecture integrates deeply with the Platform Mesh [account model](/concepts/account-model), ensuring that security boundaries align with organizational boundaries throughout the hierarchy.
+
+- **Per-organization identity realm:** Platform Mesh creates a dedicated Keycloak realm for each organization, providing complete isolation of user stores, client configurations, and authentication policies. This realm is configured as an OIDC provider through [kcp](https://kcp.io)'s authentication configuration, tying the organization's identity management directly to its account hierarchy.
+- **Per-organization FGA store:** Similarly, each organization receives a dedicated OpenFGA store, isolating authorization state across organizational boundaries. This ensures that relationship tuples and authorization evaluations for one organization cannot interfere with another.
+- **Dynamic authorization schema:** Platform Mesh dynamically generates the OpenFGA authorization schema for each organization based on the APIs bound within that organization's accounts. As [service providers](/concepts/personas/service-provider) expose new capabilities and consumers bind to them, the authorization model automatically evolves to include the corresponding types and relations, eliminating the need for manual schema maintenance.
+- **Hierarchical inheritance:** OpenFGA relationship tuples can be inherited through the account hierarchy. Permissions defined at a parent account can propagate to child accounts through the relationship graph, simplifying governance while allowing overrides where organizational requirements demand it.
+- **Service-relationship authorization:** When [service consumers](/concepts/personas/service-consumer) engage with [service providers](/concepts/personas/service-provider) through the export and bind mechanisms of the account model, the authorization layer automatically reflects these relationships. OpenFGA also controls where in the account hierarchy a provider's service can be bound, ensuring that service consumption is constrained to the appropriate organizational scope.
+- **Marketplace integration:** When a provider API is activated through a [marketplace](/reference/components/marketplace), the OpenFGA authorization schema for the organization is extended to include the corresponding resource types and relations, making the new service's resources available for fine-grained authorization decisions.
+
+## Related
+
+- [Authentication](./authentication) — design view of how identity is established
+- [Authorization](./authorization) — design view of layered RBAC + ReBAC decisions
+- [Identity and authorization](/concepts/identity-and-authorization) — runtime view of the same components
+- [Account model](/concepts/account-model) — organizational hierarchy that frames per-org isolation
+- [Keycloak](/reference/components/keycloak) — reference for the identity provider component
+- [OpenFGA](/reference/components/openfga) — reference for the authorization engine component
+- [rebac-authz-webhook](/reference/components/rebac-authz-webhook) — reference for the kcp ↔ OpenFGA bridge

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "markdown-it-footnote": "^4.0.0",
         "medium-zoom": "^1.1.0"
       },
       "devDependencies": {
@@ -3116,6 +3117,12 @@
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
       "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-it-footnote": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
+      "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
       "license": "MIT"
     },
     "node_modules/marked": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vitepress preview"
   },
   "dependencies": {
+    "markdown-it-footnote": "^4.0.0",
     "medium-zoom": "^1.1.0"
   }
 }


### PR DESCRIPTION
## Summary

Adds a new "Security architecture" subsection under `/concepts/` covering authentication, authorization, and how security maps to the account model. This is a rework of #114 by @xmudrii against the v0.3 Diátaxis IA introduced in #115.

## What's here

- `concepts/security/index.md` — overview, separation of concerns, identity propagation, and a "Security and the account model" section (folded in from the original `account-model.md`).
- `concepts/security/authentication.md` — OIDC, Keycloak, federation.
- `concepts/security/authorization.md` — RBAC + OpenFGA (ReBAC), layered evaluation.
- New "Security architecture" sidebar group between "Account and control plane" and "API and integration".
- `markdown-it-footnote` for footnote rendering (used by the new pages; useful site-wide).
- Cross-link from the existing `/concepts/identity-and-authorization` page (runtime view) to the new section (design view).

## How this differs from #114

- **Diátaxis fit:** new section sits alongside the existing `identity-and-authorization` page. That page keeps the runtime view (components, authorizer chain); these new pages cover the design view (separation of concerns, OIDC federation, ReBAC, account-model integration). Both link to each other.
- **Links:** every v0.2 path (`/overview/account-model`, `/overview/control-planes`, `/overview/design-decision`, `.md` suffixes) updated to v0.3 canonical paths.
- **Glossary mechanic dropped:** `<Term>` / `<Project>` Vue components, `.data.ts` loaders, and the two `platform-mesh-*.json` files are not carried over. Term references are plain markdown links to the canonical concept/persona/reference pages. If we want a glossary tooltip mechanic later, that's a separate PR with site-wide scope.
- **Diagram simplified:** the original 11-node flowchart is split into two — "Client entry paths" and "Authentication and authorization flow inside kcp". MCP labelled `(planned)`.
- **`account-model.md` folded** into `index.md` as a section (was 10 lines on its own, now richer in context).
- **Cross-Diátaxis links** added on every page to relevant `/reference/components/...` pages and back to the runtime view.

Closes #114 (superseded — credit retained via co-author trailer).

## Test plan

- [ ] `npm run build` clean
- [ ] `DOCS_VERSION=main npm run build && npm run preview` — check `/main/concepts/security/` renders, sidebar shows "Security architecture" group, mermaid + footnotes render
- [ ] Click every cross-ref on the three new pages
- [ ] Verify the new "Security architecture" entry on `/concepts/identity-and-authorization` navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)