### PR TITLE
docs(security): rewrite security policy page

### DIFF
--- a/reference/security/index.md
+++ b/reference/security/index.md
@@ -9,31 +9,31 @@ The scope of this document is:
 
 [SECURITY.md]: https://github.com/platform-mesh/.github/blob/main/SECURITY.md
 
-## Security Response Team
+## Security response team
 
-A dedicated **Security Response Team** is responsible for all vulnerability-related activity. Responsibilities include receiving and acknowledging vulnerability reports, reviewing automated findings, coordinating fixes, publishing GitHub Security Advisories and CVEs, and communicating with reporters and users throughout the process.
+A dedicated Security Response Team is responsible for all vulnerability-related activity. Responsibilities include receiving and acknowledging vulnerability reports, reviewing automated findings, coordinating fixes, publishing GitHub Security Advisories and CVEs, and communicating with reporters and users throughout the process.
 
 For an up-to-date list of all team members, see [the `platform-mesh/security` GitHub team](https://github.com/orgs/platform-mesh/teams/security).
 
-## Staying Up to Date
+## Staying up to date
 
-Information about security fixes in Platform Mesh and updates to vulnerable dependencies is published in **the changelog** with each new release.
+Information about security fixes in Platform Mesh and updates to vulnerable dependencies is published in **the changelog** with each release.
 
 Security fixes in Platform Mesh are also announced on the [`PlatformMesh-Announcement` mailing list](https://lists.neonephos.org/g/PlatformMesh-Announcement). For high and critical severity vulnerabilities, a pre-announcement is sent to the mailing list at least 24 hours before the release.
 
-Users are encouraged to:
+To receive security announcements:
 
-- [Subscribe to the mailing list](https://lists.neonephos.org/g/PlatformMesh-Announcement) to receive security announcements and pre-announcements.
-- [Subscribe to release notifications](https://github.blog/changelog/2018-11-26-watch-releases/) for the Platform Mesh repositories they use.
+- [Subscribe to the `PlatformMesh-Announcement` mailing list](https://lists.neonephos.org/g/PlatformMesh-Announcement) for security announcements and pre-announcements.
+- [Subscribe to release notifications](https://github.blog/changelog/2018-11-26-watch-releases/) for relevant Platform Mesh repositories.
 
-## Reporting Vulnerabilities
+## Reporting vulnerabilities
 
 Do **NOT**:
 
 - Report potential security vulnerabilities through GitHub issues or other public channels
 - Contact Security Response Team members directly
 
-**Instead, follow the process explained in the [SECURITY.md] file.**
+Instead, follow the process explained in the [SECURITY.md] file.
 
 Platform Mesh follows the principle of [Coordinated Vulnerability Disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure). Reporters are asked to:
 
@@ -47,40 +47,45 @@ The Security Response Team commits to:
 - Providing an estimated timeline for a fix.
 - Notifying the reporter when the vulnerability is resolved.
 
-## Handling Security Vulnerabilities
+## Handling security vulnerabilities
 
-### Direct Vulnerability Reports
+### Direct vulnerability reports
 
-When a vulnerability report arrives, the Security Response Team reviews it and, if needed, takes action to fix or mitigate the vulnerability in a private fork of the affected repository. Once ready, the fix is included in the next release. For vulnerabilities rated high or critical, an out-of-band release is performed. The security fix may be backported to previous releases.
+When a vulnerability report arrives, the Security Response Team reviews it and, if needed, takes action to fix or mitigate the vulnerability in a private fork of the affected repository. Once ready, the fix is included in the next release. For vulnerabilities rated high or critical, an out-of-band release is performed. Depending on the affected repository's release policy, the security fix is backported to previous releases.
 
 **NOTE:** Reports that consist solely of automated scanner output — without proof that the vulnerability is reachable in Platform Mesh — require additional investigation before being treated as confirmed vulnerabilities. The Security Response Team evaluates whether the affected code path is actually invoked in Platform Mesh. If the vulnerability is confirmed to be reachable, it is handled as a confirmed vulnerability. If not, the reporter is notified and the report is closed.
 
-#### Low and Medium Severity Vulnerabilities
+#### Low and medium severity vulnerabilities
 
 In most cases, vulnerabilities rated low or medium are **not** pre-announced. Full details are disclosed when the release containing the fix is published. Platform Mesh does not issue a CVE number for these vulnerabilities, but a GitHub Security Advisory is published alongside the release.
 
-#### High and Critical Severity Vulnerabilities
+#### High and critical severity vulnerabilities
 
 Vulnerabilities rated high and critical are communicated differently from low and medium severity vulnerabilities:
 
-- A security release pre-announcement is sent at least 24 hours before the release without disclosing details about the vulnerability
-- Security releases are created according to the timeline stated in the pre-announcement
-- Details about vulnerabilities are published 24–48 hours after the security releases are created
+- A security release pre-announcement is sent at least 24 hours before the release without disclosing details about the vulnerability.
+- Security releases are created according to the timeline stated in the pre-announcement.
+- Details about vulnerabilities are published 24–48 hours after the security releases are created.
 
 Both a CVE number and a GitHub Security Advisory are issued for these vulnerabilities.
 
-### Vulnerabilities in Dependencies
+### Vulnerabilities in dependencies
 
 Like every project that uses external dependencies, Platform Mesh is potentially vulnerable to issues discovered in those dependencies. In many cases, those vulnerabilities are not actually exploitable within Platform Mesh. To minimize risks, the project uses tooling that automatically updates affected dependencies when a vulnerability is discovered or published.
 
 Updates to vulnerable dependencies are typically included in regular scheduled releases and communicated exclusively through the changelog. Vulnerabilities in dependencies that are rated high or critical and confirmed to be exploitable in Platform Mesh are an exception and are handled following the same process as [high and critical severity vulnerabilities](#high-and-critical-severity-vulnerabilities).
 
-Platform Mesh does not issue a CVE number or GitHub Security Advisory for vulnerabilities in dependencies, as one will already exist for the affected upstream project.
+Platform Mesh does not issue a CVE number or GitHub Security Advisory for vulnerabilities in dependencies, because a CVE number or advisory already exists from the upstream project.
 
-### Information Disclosure
+### Information disclosure
 
 Public disclosure happens through GitHub Security Advisories. Each advisory contains a description, affected versions, patched versions, and CVSS severity. For high and critical severity vulnerabilities, a CVE number is also issued. The fix is highlighted in the changelog under a dedicated **Security Fixes** section. The advisory is automatically published to the GitHub Advisory Database, so downstream projects are also notified via GitHub.
 
-## Security Posture
+## Security posture
 
 The Platform Mesh project runs regular automated checks to ensure a strong security posture in all user-facing repositories. OpenSSF Scorecard is used for this purpose. For more details, see the [OpenSSF Scorecard document](./scorecard.md).
+
+## Related
+
+- [OpenSSF Scorecard](./scorecard.md) — automated security posture checks for Platform Mesh repositories
+- [SECURITY.md](https://github.com/platform-mesh/.github/blob/main/SECURITY.md) — the reporting process referenced throughout this page

--- a/reference/security/index.md
+++ b/reference/security/index.md
@@ -1,6 +1,6 @@
 # Security
 
-The Platform Mesh project hosts many different user-facing repositories under the [`platform-mesh`](https://github.com/platform-mesh) GitHub organization. This page describes how the project detects, triages, remediates, and discloses security vulnerabilities.
+The Platform Mesh project hosts many different user-facing repositories under the [`platform-mesh`](https://github.com/platform-mesh) GitHub organization. This page describes how the project receives reports of, triages, remediates, and discloses security vulnerabilities.
 
 The scope of this document is:
 
@@ -9,71 +9,78 @@ The scope of this document is:
 
 [SECURITY.md]: https://github.com/platform-mesh/.github/blob/main/SECURITY.md
 
-## Security response team
+## Security Response Team
 
-A dedicated Security Response Team owns all vulnerability-related activity. Responsibilities include receiving and acknowledging vulnerability reports, reviewing automated findings, coordinating fixes, publishing GitHub Security Advisories and CVEs, and communicating with reporters and users throughout the process.
+A dedicated **Security Response Team** is responsible for all vulnerability-related activity. Responsibilities include receiving and acknowledging vulnerability reports, reviewing automated findings, coordinating fixes, publishing GitHub Security Advisories and CVEs, and communicating with reporters and users throughout the process.
 
 For an up-to-date list of all team members, see [the `platform-mesh/security` GitHub team](https://github.com/orgs/platform-mesh/teams/security).
 
-## Reporting vulnerabilities
+## Staying Up to Date
+
+Information about security fixes in Platform Mesh and updates to vulnerable dependencies is published in **the changelog** with each new release.
+
+Security fixes in Platform Mesh are also announced on the [`PlatformMesh-Announcement` mailing list](https://lists.neonephos.org/g/PlatformMesh-Announcement). For high and critical severity vulnerabilities, a pre-announcement is sent to the mailing list at least 24 hours before the release.
+
+Users are encouraged to:
+
+- [Subscribe to the mailing list](https://lists.neonephos.org/g/PlatformMesh-Announcement) to receive security announcements and pre-announcements.
+- [Subscribe to release notifications](https://github.blog/changelog/2018-11-26-watch-releases/) for the Platform Mesh repositories they use.
+
+## Reporting Vulnerabilities
 
 Do **NOT**:
 
 - Report potential security vulnerabilities through GitHub issues or other public channels
-- Reach out to specific Security Response Team members directly
+- Contact Security Response Team members directly
 
-Instead, follow the process explained in the [SECURITY.md] file.
+**Instead, follow the process explained in the [SECURITY.md] file.**
 
-## Staying up to date
+Platform Mesh follows the principle of [Coordinated Vulnerability Disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure). Reporters are asked to:
 
-Information about security fixes and dependency updates is disclosed in **the changelog** when a new release is published. All users are encouraged to [subscribe to release notifications](https://github.blog/changelog/2018-11-26-watch-releases/) in GitHub repositories of projects they use.
+- Allow reasonable time to investigate and address the issue before making any information public.
+- Make a good faith effort to avoid privacy violations, data destruction, and disruption of services.
+- Not exploit the vulnerability beyond what is necessary to verify it.
 
-## Handling security vulnerabilities
+The Security Response Team commits to:
 
-This section describes how security vulnerabilities are handled, assessed, fixed, and communicated to the end user community.
+- Acknowledging receipt of the vulnerability report.
+- Providing an estimated timeline for a fix.
+- Notifying the reporter when the vulnerability is resolved.
 
-### Direct vulnerability reports
+## Handling Security Vulnerabilities
 
-When a vulnerability report arrives, the Security Response Team acts on it immediately. The reporter receives an acknowledgement within one business day of submitting a report.
+### Direct Vulnerability Reports
 
-The Security Response Team performs an assessment and, if needed, takes action to fix or mitigate the vulnerability in a private fork of the affected repository. Once ready, the fix is included in the next release. For vulnerabilities classified as high or critical severity, an out-of-band release is performed. Depending on the affected repository's release policy, the security fix is backported to previous releases.
+When a vulnerability report arrives, the Security Response Team reviews it and, if needed, takes action to fix or mitigate the vulnerability in a private fork of the affected repository. Once ready, the fix is included in the next release. For vulnerabilities rated high or critical, an out-of-band release is performed. The security fix may be backported to previous releases.
 
-**NOTE:** Reports that consist solely of automated scanner output — without proof that the vulnerability is reachable in Platform Mesh — are not treated as confirmed vulnerabilities. The team evaluates whether the affected code path is actually invoked. This policy applies equally to direct reports and automated findings.
+**NOTE:** Reports that consist solely of automated scanner output — without proof that the vulnerability is reachable in Platform Mesh — require additional investigation before being treated as confirmed vulnerabilities. The Security Response Team evaluates whether the affected code path is actually invoked in Platform Mesh. If the vulnerability is confirmed to be reachable, it is handled as a confirmed vulnerability. If not, the reporter is notified and the report is closed.
 
-Communication to the end user community depends on the severity of the vulnerability.
+#### Low and Medium Severity Vulnerabilities
 
-#### Low and medium severity vulnerabilities
+In most cases, vulnerabilities rated low or medium are **not** pre-announced. Full details are disclosed when the release containing the fix is published. Platform Mesh does not issue a CVE number for these vulnerabilities, but a GitHub Security Advisory is published alongside the release.
 
-In most cases, vulnerabilities rated as low and medium are **not** pre-announced. Those vulnerabilities, including their details, are communicated when a release containing the fix is published. Platform Mesh does not issue a CVE number for these vulnerabilities; only a GitHub Security Advisory is published.
+#### High and Critical Severity Vulnerabilities
 
-#### High and critical severity vulnerabilities
+Vulnerabilities rated high and critical are communicated differently from low and medium severity vulnerabilities:
 
-Vulnerabilities rated high and critical are communicated differently from other vulnerabilities:
-
-- A security release pre-announcement is sent at least 24 hours before the release without any details about the vulnerability being fixed
-- Security releases are created according to the communicated timeline
+- A security release pre-announcement is sent at least 24 hours before the release without disclosing details about the vulnerability
+- Security releases are created according to the timeline stated in the pre-announcement
 - Details about vulnerabilities are published 24–48 hours after the security releases are created
 
 Both a CVE number and a GitHub Security Advisory are issued for these vulnerabilities.
 
-#### Information disclosure
+### Vulnerabilities in Dependencies
 
-Public disclosure happens through GitHub Security Advisories. A draft advisory is created on the affected repository when a report is received, enabling confidential fix development via Private Security Forks.
+Like every project that uses external dependencies, Platform Mesh is potentially vulnerable to issues discovered in those dependencies. In many cases, those vulnerabilities are not actually exploitable within Platform Mesh. To minimize risks, the project uses tooling that automatically updates affected dependencies when a vulnerability is discovered or published.
 
-Each advisory must contain a description, affected versions, patched versions, CVSS severity, and a CVE identifier (if applicable). The fix is highlighted in the changelog under a dedicated **Security Fixes** section. The advisory automatically feeds into the GitHub Advisory Database, so downstream consumers of libraries are also notified via GitHub.
+Updates to vulnerable dependencies are typically included in regular scheduled releases and communicated exclusively through the changelog. Vulnerabilities in dependencies that are rated high or critical and confirmed to be exploitable in Platform Mesh are an exception and are handled following the same process as [high and critical severity vulnerabilities](#high-and-critical-severity-vulnerabilities).
 
-### Vulnerabilities in dependencies
+Platform Mesh does not issue a CVE number or GitHub Security Advisory for vulnerabilities in dependencies, as one will already exist for the affected upstream project.
 
-Like every project that uses external dependencies, Platform Mesh is potentially vulnerable to issues discovered in those dependencies. In many cases, those vulnerabilities are not actually exploitable within the project, but to minimize risks, the project uses tooling that automatically updates dependencies for which a vulnerability is discovered or published.
+### Information Disclosure
 
-In most cases, there are no special out-of-band releases for vulnerable dependency updates; those updates are included in regular scheduled releases. No special communication is issued for these updates — all information is included in the changelog when a release is published. Platform Mesh does not issue a CVE number or GitHub Security Advisory in these cases, because a CVE number or Advisory already exists from the dependent project.
+Public disclosure happens through GitHub Security Advisories. Each advisory contains a description, affected versions, patched versions, and CVSS severity. For high and critical severity vulnerabilities, a CVE number is also issued. The fix is highlighted in the changelog under a dedicated **Security Fixes** section. The advisory is automatically published to the GitHub Advisory Database, so downstream projects are also notified via GitHub.
 
-An exception is highly-rated vulnerabilities that can be exploited; those are handled similarly to high and critical severity vulnerabilities in Platform Mesh:
+## Security Posture
 
-- A security release pre-announcement is sent at least 24 hours before the release without any details about the vulnerable dependency
-- Security releases are created according to the communicated timeline
-- Details about vulnerabilities are published 24–48 hours after the security releases are created
-
-## Security posture
-
-The Platform Mesh project runs frequent checks to ensure the proper security posture in all user-facing repositories. OpenSSF Scorecard is used for this purpose. For more details, see the [OpenSSF Scorecard document](./scorecard.md).
+The Platform Mesh project runs regular automated checks to ensure a strong security posture in all user-facing repositories. OpenSSF Scorecard is used for this purpose. For more details, see the [OpenSSF Scorecard document](./scorecard.md).


### PR DESCRIPTION
## Summary

Complete rewrite of `reference/security/index.md` to improve clarity, accuracy, and usefulness for both end users and vulnerability reporters.

### Policy changes

- Acknowledgement SLA removed
- CVD commitments section moved here from SECURITY.md and rewritten in   third-person; this page is now the authoritative source, to be linked from SECURITY.md
- Added PlatformMesh-Announcement mailing list as a channel for security fix announcements and high/critical pre-announcements
- Scanner-only reports: clarified handling with explicit outcomes — confirmed reachable → handled as vulnerability; not reachable → reporter notified and report closed
- Dependency vulnerability exception now requires the vulnerability to be rated high or critical **and** confirmed exploitable in Platform Mesh
- Removed duplicated pre-announcement bullet block from the dependency section (was copy-pasted from the direct reports section)
- Backporting policy simplified — removed reference to a non-existent per-repository policy

### Structural changes

- "Staying Up to Date" moved before "Reporting Vulnerabilities" to prioritise the end user audience
- "Information Disclosure" promoted from `####` to `###` and moved after "Vulnerabilities in Dependencies", as it applies to both sections
- Subscription guidance converted to a bullet list

### Style and wording

- All headings converted to title case
- Consistent third-person voice throughout
- Numerous wording improvements for clarity and formality

cc @mirzakopic 