### PR TITLE
docs: update community pages

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -33,6 +33,10 @@ export default withMermaid({
 
   description: "Platform Mesh - Building upon the Kubernetes API & Resource Model",
 
+  // Internal design specs and notes live under docs/superpowers/ and are not
+  // part of the published docs site. Exclude them from VitePress's source scan.
+  srcExclude: ['docs/superpowers/**'],
+
   // Auto-redirect stub pages: any page with `redirect: /new/path` in its frontmatter
   // gets a <meta http-equiv="refresh"> tag injected. Old v0.2 URLs that map to a
   // single new location use this to bounce visitors automatically; the visible
@@ -76,7 +80,7 @@ export default withMermaid({
       { text: 'How-to guides', link: '/how-to-guides/' },
       { text: 'Concepts', link: '/concepts/' },
       { text: 'Reference', link: '/reference/' },
-      { text: 'Get involved', link: '/get-involved' },
+      { text: 'Community', link: '/community/' },
     ],
 
     logo: {
@@ -231,6 +235,18 @@ export default withMermaid({
             link: '/reference/security/',
             items: [
             { text: 'OpenSSF Scorecard', link: '/reference/security/scorecard' },
+            ]
+        }
+      ],
+
+      '/community/': [
+        {
+            text: 'Community',
+            items: [
+            { text: 'Welcome', link: '/community/' },
+            { text: 'Chat', link: '/community/chat' },
+            { text: 'Community calls', link: '/community/calls' },
+            { text: 'Talks', link: '/community/talks' },
             ]
         }
       ],

--- a/community/calls.md
+++ b/community/calls.md
@@ -1,0 +1,21 @@
+# Community calls
+
+Platform Mesh community calls are open meetings for project discussions, demos, and Q&A.
+
+::: info
+The first community call has not yet taken place. This page is updated with the schedule and joining instructions once announced.
+:::
+
+## Schedule
+
+TBD.
+
+## How to join
+
+TBD.
+
+## Agenda and notes
+
+TBD.
+
+Recorded talks and presentations are listed under [Talks](./talks.md).

--- a/community/chat.md
+++ b/community/chat.md
@@ -1,0 +1,18 @@
+# Chat
+
+Platform Mesh chat lives on the [Linux Foundation Zulip server](https://linuxfoundation.zulipchat.com/). Two channels cover most conversations.
+
+## Channels
+
+| Channel | Use it for |
+| --- | --- |
+| [`neonephos-platform-mesh-discussion`](https://linuxfoundation.zulipchat.com/#narrow/channel/532985-neonephos-platform-mesh-discussion) | Design discussions, RFCs, and general questions about Platform Mesh. |
+| [`neonephos-platform-mesh-support`](https://linuxfoundation.zulipchat.com/#narrow/channel/532986-neonephos-platform-mesh-support) | Help with installing, running, or operating Platform Mesh. |
+
+## Don't report security issues in chat
+
+Posting a vulnerability in public chat exposes it to potential attackers before a fix exists. Follow the [security policy](/reference/security/) to report it through the project's private intake.
+
+## Code of conduct
+
+The [Code of Conduct](https://github.com/platform-mesh/.github/blob/main/CODE_OF_CONDUCT.md) applies in all channels.

--- a/community/index.md
+++ b/community/index.md
@@ -1,0 +1,29 @@
+# Community
+
+Platform Mesh is open source and developed in the open. This section covers where the project lives, how to talk with the community, and how to contribute.
+
+## Where the project lives
+
+Platform Mesh is hosted on GitHub:
+
+- [github.com/platform-mesh](https://github.com/platform-mesh) — the organization and all repositories.
+- [Set up Platform Mesh locally](/how-to-guides/set-up-platform-mesh-locally) — install on a development machine.
+- [Tutorials](/tutorials/) — guided walkthroughs.
+
+## Where to find people
+
+- [Chat](./chat.md) — async conversation on the Linux Foundation Zulip server.
+- [Community calls](./calls.md) — live discussions, demos, and Q&A.
+- [Talks](./talks.md) — recorded presentations and conference sessions.
+
+## How to contribute
+
+Platform Mesh welcomes contributions from the community. The project's [contributing guide](https://github.com/platform-mesh/.github/blob/main/CONTRIBUTING.md) covers how to find work, open pull requests, and review changes.
+
+## Code of conduct
+
+Platform Mesh follows the [Code of Conduct](https://github.com/platform-mesh/.github/blob/main/CODE_OF_CONDUCT.md). It applies in all project spaces — Zulip, community calls, GitHub repositories, and in-person events.
+
+## Reporting a vulnerability
+
+To report a security issue, follow the process described in the [security policy](/reference/security/). Don't report vulnerabilities through GitHub issues or in chat.

--- a/community/talks.md
+++ b/community/talks.md
@@ -1,0 +1,45 @@
+---
+outline: 2
+---
+
+# Talks
+
+This page lists Platform Mesh talks — upcoming conference sessions and recordings of past presentations.
+
+## Upcoming
+
+### Polymorphic interfaces in kcp: The three vendor problem
+
+[KCD Helsinki 2026](https://community2.cncf.io/events/details/cncf-kcd-helsinki-presents-kubernetes-community-days-helsinki-2026/) — May 20, 2026.
+
+### Platform Mesh: Breaking API Lock-In for True Multi-Cloud Service Portability
+
+[ContainerDays Hamburg 2026](https://www.containerdays.io/containerdays-hamburg-2026/) — September 2–4, 2026.
+
+## Recordings
+
+### Platform Mesh: Breaking API Lock-In for True Multi-Cloud Service Portability
+
+[KubeCon + CloudNativeCon Europe 2026](https://kccnceu2026.sched.com/) — Amsterdam, March 2026.
+
+[Watch on YouTube](https://www.youtube.com/watch?v=43X0_U3cc-Y)
+
+### Sovereignty = func(Ecosystems, Interoperability)
+
+Platform Mesh and [OCM](https://ocm.software/) in the context of sovereignty.
+
+[ALASCA Tech-Talk #35](https://alasca.cloud/en/alasca-tech-talks/).
+
+[Watch on YouTube](https://www.youtube.com/watch?v=hzkrbW_J7U0)
+
+### Polymorphic interfaces in kcp: The three vendor problem
+
+[Cloud Native Suisse Romande](https://community.cncf.io/cloud-native-suisse-romande/).
+
+[Watch on YouTube](https://www.youtube.com/watch?v=AG9-DdW32xg)
+
+### Building Europe's Cloud Future: NeoNephos and the Platform Mesh
+
+[ContainerDays Conference 2025](https://www.containerdays.io/containerdays-conference-2025/) — Hamburg, September 2025.
+
+[Watch on YouTube](https://www.youtube.com/watch?v=8GFDj_-scSQ)

--- a/get-involved.md
+++ b/get-involved.md
@@ -1,44 +1,7 @@
-# Get involved
+---
+redirect: /community/
+---
 
-Platform Mesh is an open source effort and welcomes contributions from
-the community. The projects developed in context of Platform Mesh have
-dedicated community calls, chat channels, and repositories.
+# Get involved has moved
 
-## Platform Mesh
-
-Discussions around the Platform Mesh as a whole happen in the Linux Foundation Zulip chat channel:
-
-[neonephos-platform-mesh-discussion](https://linuxfoundation.zulipchat.com/#narrow/channel/532985-neonephos-platform-mesh-discussion)
-
-## kcp
-
-[kcp](https://kcp.io/) is the Service Control Plane for Platform Mesh. It is an open source
-project hosted by the CNCF.
-
-The best starting point to get in touch is the [#kcp-users](https://kubernetes.slack.com/archives/C021U8WSAFK) channel on Kubernetes Slack and the [biweekly community calls](https://community.cncf.io/kcp/).
-
-For more information on getting involved with kcp, please see the [Getting in Touch](https://docs.kcp.io/kcp/latest/#getting-in-touch) section of the kcp documentation.
-
-### api-syncagent
-
-[api-syncagent](https://docs.kcp.io/api-syncagent/) is an operator that
-allows publishing CRDs from a control plane to APIExports in a kcp
-workspace. It is part of the kcp project.
-
-## kube-bind
-
-[kube-bind](https://kube-bind.io/) is a project that enables providers to offer their APIs to
-consumers across distinct control planes using the Kubernetes Resource
-Model.
-
-The best starting point to get in touch is the [#kube-bind](https://kubernetes.slack.com/archives/C046PRXNJ4W) channel on Kubernetes Slack.
-
-For more information on getting involved with kube-bind, please see the [Getting in Touch](https://docs.kube-bind.io/main/#getting-in-touch) section of the kube-bind documentation.
-
-## multicluster-runtime
-
-[multicluster-runtime](https://github.com/kubernetes-sigs/multicluster-runtime)
-is a library to write Kubernetes controllers that reconcile resource
-across Kubernetes-like control planes. The project is hosted by SIG Multicluster.
-
-Discussions happen in the [#sig-multicluster](https://kubernetes.slack.com/archives/C09R1PJR3) channel on Kubernetes Slack.
+This page is now [Community](/community/).


### PR DESCRIPTION
## Summary

  Replaces the single `get-involved.md` page with a new `/community/` section
  covering chat, community calls, and talks. Renames the top-nav item from
  "Get involved" to "Community". The old `/get-involved` URL now redirects
  to `/community/`.

  ## What changed

  - **New section** at `/community/` with four pages:
    - `community/index.md` — Welcome (where the project lives, where to find people, contributing, code of conduct,
  security pointer)
    - `community/chat.md` — the two LF Zulip channels (`-discussion` and `-support`), security-in-chat callout, code of
   conduct link
    - `community/calls.md` — placeholder structure (Schedule / How to join / Agenda and notes); first call has not yet
  taken place
    - `community/talks.md` — upcoming sessions (KCD Helsinki 2026, ContainerDays Hamburg 2026) and recordings (KubeCon
  EU 2026, ALASCA Tech-Talk 35, Cloud Native Suisse Romande, ContainerDays 2025)
  - **Top nav**: `Get involved` → `Community`, link `/get-involved` → `/community/`.
  - **Sidebar**: new `/community/` tree (Welcome, Chat, Community calls, Talks).
  - **Redirect**: `get-involved.md` becomes a stub with `redirect: /community/` frontmatter — `transformPageData`
  injects the `<meta http-equiv="refresh">` per the existing v0.3 redirect pattern.
  - **`srcExclude`**: `docs/superpowers/**` excluded from the VitePress source scan so internal design notes don't
  pollute the build.

  ## Design decisions

  - **Scope**: Platform Mesh umbrella project only. The previous per-project entries (kcp, kube-bind,
  multicluster-runtime, api-syncagent) drop off — readers find them via existing reference pages or the upstream
  project sites.
  - **Hub + focused subpages** over a single dense page — each major surface is its own linkable URL.
  - **Code of conduct** stays as a section on Welcome (link out to the org's `CODE_OF_CONDUCT.md`) rather than its own
  page; promotes to a page only if a project-specific supplement is later written.
  - **Security** is an outbound link to `/reference/security/` from Welcome and Chat — no content duplication.
  - **No `## Related` sections** on community pages — these aren't Diátaxis content; cross-links between Community
  pages are already in the sidebar and the Diátaxis section links live on the relevant pages.

  ## What's still TBC (follow-up)

  - `community/calls.md` — schedule, joining instructions, and agenda link (placeholder TBDs in place until the first
  call is announced).
  - `community/talks.md` — list grows as new recordings become available.
