### PR TITLE
docs: update platform-mesh-operator reference documentation

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -114,6 +114,7 @@ export default withMermaid({
             text: 'Set up and run',
             items: [
             { text: 'Set up Platform Mesh locally', link: '/how-to-guides/set-up-platform-mesh-locally' },
+            { text: 'Set up remote deployment', link: '/how-to-guides/set-up-remote-deployment' },
             { text: 'Speed up local rebuilds', link: '/how-to-guides/speed-up-local-rebuilds' },
             ]
         },

--- a/how-to-guides/index.md
+++ b/how-to-guides/index.md
@@ -5,6 +5,7 @@ How-to guides are task-focused. Use them when you already know what you want to 
 ## Set up and run
 
 - [Set up Platform Mesh locally](./set-up-platform-mesh-locally.md)
+- [Set up remote deployment](./set-up-remote-deployment.md)
 - [Speed up local rebuilds](./speed-up-local-rebuilds.md)
 
 ## Access local services

--- a/how-to-guides/set-up-remote-deployment.md
+++ b/how-to-guides/set-up-remote-deployment.md
@@ -1,0 +1,240 @@
+---
+title: Set up remote deployment
+personas: [platform-owner]
+---
+
+# Set up remote deployment
+
+Use this how-to to deploy Platform Mesh across multiple clusters, where the operator runs on one cluster but manages resources on separate runtime and infra clusters.
+
+::: warning Alpha feature
+Remote deployment is functional but limited to a single remote deployment per operator instance. APIs and Helm values may change.
+:::
+
+## Prerequisites
+
+- A running Kubernetes cluster for the operator (the **local** cluster)
+- A separate Kubernetes cluster for the runtime workloads (the **runtime** cluster) — this is where kcp, OCM, and the PlatformMesh resource live
+- Optionally, a third cluster for FluxCD or ArgoCD (the **infra** cluster) — if not provided, the local cluster serves this role
+- `kubectl` configured to access all clusters
+- Helm 3.x installed
+
+## Architecture overview
+
+```
+┌─────────────────────┐     ┌─────────────────────────────────┐
+│   Local cluster     │     │       Runtime cluster            │
+│                     │     │                                  │
+│  platform-mesh-     │────▶│  PlatformMesh CR                 │
+│  operator           │     │  Profile ConfigMap               │
+│                     │     │  kcp (RootShard, FrontProxy)     │
+│  (leader election)  │     │  OCM Resources                   │
+└─────────────────────┘     └─────────────────────────────────┘
+          │
+          │  (if Local != Infra)
+          ▼
+┌─────────────────────────────────┐
+│        Infra cluster            │
+│                                 │
+│  FluxCD / ArgoCD                │
+│  HelmReleases                   │
+│  OCIRepositories                │
+│  HelmRepositories               │
+└─────────────────────────────────┘
+```
+
+Remote deployment is considered when the **Runtime** and **Infra** clusters are different. FluxCD HelmReleases receive a `kubeConfig.secretRef` that tells FluxCD to deploy workloads to the runtime cluster. ArgoCD Applications receive a `destination.server` pointing to the runtime cluster API.
+
+## Step 1: Create a kubeconfig secret for the runtime cluster
+
+Generate a kubeconfig that gives the operator access to the runtime cluster. Create a Secret on the **local** cluster:
+
+```bash
+kubectl create secret generic platform-mesh-kubeconfig \
+  --namespace platform-mesh-system \
+  --from-file=kubeconfig=<path-to-runtime-kubeconfig>
+```
+
+## Step 2: Create a kubeconfig secret for FluxCD to reach the runtime cluster
+
+FluxCD (running on the infra cluster) needs credentials to deploy workloads to the runtime cluster. Create a Secret on the **infra** cluster:
+
+```bash
+kubectl create secret generic platform-mesh-runtime-secret \
+  --namespace platform-mesh-system \
+  --from-file=kubeconfig=<path-to-runtime-kubeconfig-for-fluxcd>
+```
+
+This secret is referenced by every HelmRelease via `spec.kubeConfig.secretRef`.
+
+## Step 3: (Optional) Create a kubeconfig secret for the infra cluster
+
+If the operator does not run on the infra cluster (that is, **Local** != **Infra**), create a Secret on the local cluster with credentials to reach the infra cluster:
+
+```bash
+kubectl create secret generic platform-mesh-infra-kubeconfig \
+  --namespace platform-mesh-system \
+  --from-file=kubeconfig=<path-to-infra-kubeconfig>
+```
+
+Skip this step if the operator runs on the same cluster as FluxCD or ArgoCD.
+
+## Step 4: Install the operator with remote deployment enabled
+
+Install the platform-mesh-operator Helm chart with remote deployment values:
+
+```bash
+helm install platform-mesh-operator \
+  oci://ghcr.io/platform-mesh/helm-charts/platform-mesh-operator \
+  --namespace platform-mesh-system --create-namespace \
+  --set remoteRuntime.enabled=true \
+  --set remoteRuntime.secretName=platform-mesh-kubeconfig \
+  --set remoteRuntime.secretKey=kubeconfig \
+  --set remoteRuntime.infra.secretName=platform-mesh-runtime-secret \
+  --set remoteRuntime.infra.secretKey=kubeconfig
+```
+
+If **Local** != **Infra**, also add:
+
+```bash
+  --set remoteInfra.enabled=true \
+  --set remoteInfra.secretName=platform-mesh-infra-kubeconfig \
+  --set remoteInfra.secretKey=kubeconfig
+```
+
+### Helm values reference
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `remoteRuntime.enabled` | `false` | Enable remote runtime cluster reconciliation |
+| `remoteRuntime.secretName` | `platform-mesh-secret` | Secret with kubeconfig to reach the runtime cluster |
+| `remoteRuntime.secretKey` | `kubeconfig` | Key within the secret |
+| `remoteRuntime.infra.secretName` | `platform-mesh-secret` | Secret for FluxCD to deploy to the runtime cluster |
+| `remoteRuntime.infra.secretKey` | `kubeconfig` | Key within the infra secret |
+| `remoteInfra.enabled` | `false` | Enable remote infra cluster (only if Local != Infra) |
+| `remoteInfra.secretName` | `platform-mesh-kubeconfig` | Secret with kubeconfig to reach the infra cluster |
+| `remoteInfra.secretKey` | `kubeconfig` | Key within the secret |
+
+## Step 5: Create the PlatformMesh resource on the runtime cluster
+
+The PlatformMesh CR and its profile ConfigMap must live on the **runtime** cluster. Switch your kubectl context to the runtime cluster and apply them:
+
+```bash
+kubectl config use-context <runtime-cluster-context>
+```
+
+Create the profile ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: platform-mesh-sample-profile
+  namespace: platform-mesh-system
+data:
+  profile.yaml: |
+    infra:
+      deploymentTechnology: fluxcd
+      certManager:
+        enabled: true
+        name: cert-manager
+        interval: 5m
+        targetNamespace: cert-manager
+        ocmResourceName: charts
+        values:
+          crds:
+            enabled: true
+    components:
+      deploymentTechnology: fluxcd
+      ocm:
+        repo:
+          name: platform-mesh
+        component:
+          name: platform-mesh
+        referencePath:
+        - name: core
+      services:
+        account-operator:
+          enabled: true
+          values:
+            ingress:
+              host: "account-operator.{{ .baseDomain }}"
+```
+
+Create the PlatformMesh resource:
+
+```yaml
+apiVersion: core.platform-mesh.io/v1alpha1
+kind: PlatformMesh
+metadata:
+  name: platform-mesh-sample
+  namespace: platform-mesh-system
+spec:
+  exposure:
+    baseDomain: example.com
+    port: 443
+    protocol: https
+  ocm:
+    repo:
+      name: platform-mesh
+    component:
+      name: platform-mesh
+    referencePath:
+    - name: core
+  kcp:
+    adminSecretRef:
+      name: platform-mesh-kcp-internal-admin-kubeconfig
+    providerConnections:
+    - endpointSliceName: core.platform-mesh.io
+      path: root:platform-mesh-system
+      secret: platform-mesh-operator-kubeconfig
+      adminAuth: true
+```
+
+The operator links the two resources by naming convention: a PlatformMesh instance named `platform-mesh-sample` expects a ConfigMap named `platform-mesh-sample-profile` in the same namespace. Override this with `spec.profileConfigMap` if needed.
+
+## Step 6: Verify the deployment
+
+Check the operator logs on the local cluster:
+
+```bash
+kubectl logs -n platform-mesh-system -l app=platform-mesh-operator --tail=50
+```
+
+Verify the PlatformMesh resource status on the runtime cluster:
+
+```bash
+kubectl get platformmesh -n platform-mesh-system -o yaml
+```
+
+Look for status conditions showing all subroutines succeeded:
+
+```yaml
+status:
+  conditions:
+  - type: DeploymentSubroutine
+    status: "True"
+  - type: Ready
+    status: "True"
+```
+
+Check that HelmReleases on the infra cluster include the kubeConfig reference:
+
+```bash
+kubectl get helmreleases -n platform-mesh-system -o yaml | grep -A3 kubeConfig
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|-------------|
+| Operator fails to start | The kubeconfig secret does not exist or has the wrong key |
+| PlatformMesh not reconciled | The CR was created on the wrong cluster — it must be on the runtime cluster |
+| HelmRelease stuck | The FluxCD `kubeConfig.secretRef` secret is missing on the infra cluster |
+| cert-manager not ready | OCIRepository not created yet — check ResourceSubroutine logs |
+
+## Related
+
+- [Platform Mesh operator reference](/reference/components/platform-mesh-operator.md)
+- [Set up Platform Mesh locally](./set-up-platform-mesh-locally.md)
+- [Architecture](/concepts/architecture.md)

--- a/how-to-guides/set-up-remote-deployment.md
+++ b/how-to-guides/set-up-remote-deployment.md
@@ -7,47 +7,61 @@ personas: [platform-owner]
 
 Use this how-to to deploy Platform Mesh across multiple clusters, where the operator runs on one cluster but manages resources on separate runtime and infra clusters.
 
+## When to use this
+
+Remote deployment fits scenarios where Platform Mesh's control-plane workloads cannot live on the same cluster as the operator. Common cases:
+
+- **Separation of concerns** — keep kcp, OCM, and the `PlatformMesh` resource on a dedicated runtime cluster, while the operator and GitOps tooling run elsewhere.
+- **Shared GitOps cluster** — a central cluster runs FluxCD or ArgoCD and rolls out releases to one or more runtime clusters.
+- **Compliance or isolation** — runtime workloads must run in a network or tenant boundary that the operator cluster cannot host.
+
+If everything runs on the same cluster, you do not need this guide.
+
 ::: warning Alpha feature
 Remote deployment is functional but limited to a single remote deployment per operator instance. APIs and Helm values may change.
 :::
 
 ## Prerequisites
 
-- A running Kubernetes cluster for the operator (the **local** cluster)
+- A running Kubernetes cluster for the operator (the **operator** cluster)
 - A separate Kubernetes cluster for the runtime workloads (the **runtime** cluster) — this is where kcp, OCM, and the PlatformMesh resource live
-- Optionally, a third cluster for FluxCD or ArgoCD (the **infra** cluster) — if not provided, the local cluster serves this role
+- Optionally, a third cluster for FluxCD or ArgoCD (the **infra** cluster) — if not provided, the operator cluster serves this role
 - `kubectl` configured to access all clusters
 - Helm 3.x installed
 
 ## Architecture overview
 
-```
-┌─────────────────────┐     ┌─────────────────────────────────┐
-│   Local cluster     │     │       Runtime cluster            │
-│                     │     │                                  │
-│  platform-mesh-     │────▶│  PlatformMesh CR                 │
-│  operator           │     │  Profile ConfigMap               │
-│                     │     │  kcp (RootShard, FrontProxy)     │
-│  (leader election)  │     │  OCM Resources                   │
-└─────────────────────┘     └─────────────────────────────────┘
-          │
-          │  (if Local != Infra)
-          ▼
-┌─────────────────────────────────┐
-│        Infra cluster            │
-│                                 │
-│  FluxCD / ArgoCD                │
-│  HelmReleases                   │
-│  OCIRepositories                │
-│  HelmRepositories               │
-└─────────────────────────────────┘
+```mermaid
+graph LR
+    subgraph Operator["Operator cluster"]
+        OP["platform-mesh-operator<br/>(leader election)"]
+    end
+
+    subgraph Runtime["Runtime cluster"]
+        PM["PlatformMesh CR"]
+        PROF["Profile ConfigMap"]
+        KCP["kcp (RootShard, FrontProxy)"]
+        OCM["OCM Resources"]
+    end
+
+    subgraph Infra["Infra cluster (optional)"]
+        FLUX["FluxCD / ArgoCD"]
+        HR["HelmReleases"]
+        OCI["OCIRepositories"]
+        APPS["HelmRepositories"]
+    end
+
+    OP -->|"reconciles"| PM
+    OP -->|"reads"| PROF
+    OP -->|"creates"| HR
+    FLUX -->|"deploys via kubeConfig secret"| Runtime
 ```
 
 Remote deployment is considered when the **Runtime** and **Infra** clusters are different. FluxCD HelmReleases receive a `kubeConfig.secretRef` that tells FluxCD to deploy workloads to the runtime cluster. ArgoCD Applications receive a `destination.server` pointing to the runtime cluster API.
 
 ## Step 1: Create a kubeconfig secret for the runtime cluster
 
-Generate a kubeconfig that gives the operator access to the runtime cluster. Create a Secret on the **local** cluster:
+Generate a kubeconfig that gives the operator access to the runtime cluster. Create a Secret on the **operator** cluster:
 
 ```bash
 kubectl create secret generic platform-mesh-kubeconfig \
@@ -69,7 +83,7 @@ This secret is referenced by every HelmRelease via `spec.kubeConfig.secretRef`.
 
 ## Step 3: (Optional) Create a kubeconfig secret for the infra cluster
 
-If the operator does not run on the infra cluster (that is, **Local** != **Infra**), create a Secret on the local cluster with credentials to reach the infra cluster:
+If the operator does not run on the infra cluster (that is, **Operator** != **Infra**), create a Secret on the operator cluster with credentials to reach the infra cluster:
 
 ```bash
 kubectl create secret generic platform-mesh-infra-kubeconfig \
@@ -94,7 +108,7 @@ helm install platform-mesh-operator \
   --set remoteRuntime.infra.secretKey=kubeconfig
 ```
 
-If **Local** != **Infra**, also add:
+If **Operator** != **Infra**, also add:
 
 ```bash
   --set remoteInfra.enabled=true \
@@ -111,7 +125,7 @@ If **Local** != **Infra**, also add:
 | `remoteRuntime.secretKey` | `kubeconfig` | Key within the secret |
 | `remoteRuntime.infra.secretName` | `platform-mesh-secret` | Secret for FluxCD to deploy to the runtime cluster |
 | `remoteRuntime.infra.secretKey` | `kubeconfig` | Key within the infra secret |
-| `remoteInfra.enabled` | `false` | Enable remote infra cluster (only if Local != Infra) |
+| `remoteInfra.enabled` | `false` | Enable remote infra cluster (only if Operator != Infra) |
 | `remoteInfra.secretName` | `platform-mesh-kubeconfig` | Secret with kubeconfig to reach the infra cluster |
 | `remoteInfra.secretKey` | `kubeconfig` | Key within the secret |
 
@@ -182,8 +196,6 @@ spec:
     referencePath:
     - name: core
   kcp:
-    adminSecretRef:
-      name: platform-mesh-kcp-internal-admin-kubeconfig
     providerConnections:
     - endpointSliceName: core.platform-mesh.io
       path: root:platform-mesh-system
@@ -195,7 +207,7 @@ The operator links the two resources by naming convention: a PlatformMesh instan
 
 ## Step 6: Verify the deployment
 
-Check the operator logs on the local cluster:
+Check the operator logs on the operator cluster:
 
 ```bash
 kubectl logs -n platform-mesh-system -l app=platform-mesh-operator --tail=50

--- a/reference/components/platform-mesh-operator.md
+++ b/reference/components/platform-mesh-operator.md
@@ -234,7 +234,7 @@ The ConfigMap must contain a `profile.yaml` key with two sections:
 - **`infra`** — infrastructure components (cert-manager, traefik, etcd-druid, gateway-api) with enabled state, Helm values, intervals
 - **`components`** — application services with enabled state, chart source, Helm values, dependsOn, syncWave, imageResources
 
-The profile itself is rendered as a Go template with variables derived from `spec.exposure` (e.g., `{{ .baseDomain }}`).
+The profile itself is rendered as a Go template with variables derived from `spec.exposure` (for example, <code v-pre>{{ .baseDomain }}</code>).
 
 ### Configuration and values flow
 

--- a/reference/components/platform-mesh-operator.md
+++ b/reference/components/platform-mesh-operator.md
@@ -13,7 +13,7 @@ This component is in alpha. APIs may change on short notice, including breaking 
 
 Given a `PlatformMesh` resource the operator:
 
-1. Deploys infrastructure and application components via FluxCD HelmReleases and OCM Resources.
+1. Deploys infrastructure and application components via FluxCD HelmReleases (or ArgoCD Applications) and OCM Resources.
 2. Configures kcp workspaces, provider connections, and API bindings.
 3. Generates scoped kubeconfig secrets for cross-cluster communication.
 4. Applies feature toggles (UI content configurations, authentication behavior).
@@ -66,9 +66,10 @@ spec:
 |-------|-------------|
 | `exposure` | External exposure settings: `baseDomain`, `port`, `protocol` |
 | `kcp` | kcp workspace topology: provider connections, extra workspaces, API bindings |
-| `values` | Free-form JSON passed as Helm values to the `platform-mesh-operator-components` chart |
-| `infraValues` | Free-form JSON passed as Helm values to the `platform-mesh-operator-infra-components` chart |
+| `values` | Free-form JSON deep-merged with the profile's `components` section and passed as Helm values to each service |
+| `infraValues` | Free-form JSON merged with the profile's `infra` section |
 | `ocm` | OCM repository, component name, and reference path for component delivery |
+| `profileConfigMap` | Optional reference to profile ConfigMap (name/namespace). Defaults to `<instance-name>-profile` in the instance namespace |
 | `featureToggles` | List of named feature flags (see [Feature toggles](#feature-toggles)) |
 | `wait` | Custom readiness criteria for dependent resources |
 
@@ -91,7 +92,7 @@ The operator runs two independent controllers:
 | Controller | Watches | Purpose |
 |------------|---------|---------|
 | `PlatformMeshReconciler` | `PlatformMesh` (`core.platform-mesh.io/v1alpha1`) | Bootstraps and maintains the environment via subroutines |
-| `ResourceReconciler` | `Resource` (`delivery.ocm.software/v1alpha1`) | Syncs OCM-resolved artifacts into FluxCD sources and HelmReleases |
+| `ResourceReconciler` | `Resource` (`delivery.ocm.software/v1alpha1`) | Syncs OCM-resolved artifacts into FluxCD sources / ArgoCD Applications |
 
 ## PlatformMesh subroutines
 
@@ -100,15 +101,17 @@ Each can be individually enabled or disabled via operator flags.
 
 ### Deployment
 
-Deploys platform-mesh infrastructure and application components:
+Deploys platform-mesh infrastructure and application components using Go templates:
 
-- Templates and applies `platform-mesh-operator-infra-components` (HelmRelease + OCM Resource), then waits for readiness.
-- Templates and applies `platform-mesh-operator-components` (HelmRelease + OCM Resource).
+- Reads the profile ConfigMap and renders Go templates from `gotemplates/infra/` and `gotemplates/components/`.
+- Creates OCM Resources, HelmReleases (FluxCD) or Applications (ArgoCD) for each enabled service.
+- The profile's `components.services.<name>.values` (broad config) are deep-merged with `PlatformMesh.spec.values` (overrides), processed through Go template variable substitution, and passed 1-to-1 as `spec.values` to each service's HelmRelease or as `helm.values` to each ArgoCD Application.
 - Manages the authorization webhook secret (issuer, certificate, kcp webhook, CA bundle).
-- Waits for the Istio control plane (`istio-istiod` HelmRelease if istio is enabled).
+- Waits for cert-manager to be ready before deploying component services.
+- Waits for the Istio control plane (`istio-istiod` if Istio is enabled).
 - Waits for kcp infrastructure (`RootShard`, `FrontProxy`).
 
-Values from `spec.values` and `spec.infraValues` are templated with `baseDomain`, `baseDomainPort`, `port`, `protocol`, and `iamWebhookCA` before being written to HelmRelease objects.
+Template variables available include `baseDomain`, `baseDomainPort`, `port`, `protocol`, `iamWebhookCA`, `helmReleaseNamespace`, `kubeConfigEnabled`, and `deploymentTechnology`.
 
 ### KcpSetup
 
@@ -137,7 +140,7 @@ Applies optional feature-flag manifests during reconciliation (disabled by defau
 
 Blocks reconciliation until downstream resources satisfy readiness criteria:
 
-- By default waits for `platform-mesh-operator-components` and `platform-mesh-operator-infra-components` HelmReleases to report `Ready=True`.
+- By default waits for the `platform-mesh-operator-infra-components` HelmRelease to report `Ready=True`.
 - Custom criteria can be defined in `spec.wait.resourceTypes`:
 
 ```yaml
@@ -158,10 +161,12 @@ Fills in default values for `ocm.repo.name` and `ocm.component.name` when not ex
 
 ## ResourceReconciler
 
-A separate read-only controller that watches OCM `Resource` objects (`delivery.ocm.software/v1alpha1`).
-When an OCM Resource's status is updated with resolved artifact information, this controller syncs those references into the corresponding FluxCD objects so that Flux can fetch and deploy them.
+A separate controller that watches OCM `Resource` objects (`delivery.ocm.software/v1alpha1`).
+When an OCM Resource's status is updated with resolved artifact information, this controller syncs those references into the corresponding FluxCD or ArgoCD objects so that the deployment technology can fetch and deploy them.
 
-The behavior is driven by `repo` and `artifact` annotations (or labels) on the Resource object:
+The deployment technology is determined from the profile ConfigMap (`deploymentTechnology: fluxcd` or `argocd`).
+
+**FluxCD mode** — behavior is driven by `repo` and `artifact` annotations (or labels) on the Resource object:
 
 | `repo` | `artifact` | Action |
 |--------|-----------|--------|
@@ -169,6 +174,13 @@ The behavior is driven by `repo` and `artifact` annotations (or labels) on the R
 | `git` | `chart` | Creates/updates a FluxCD `GitRepository` with the resolved commit and repo URL |
 | `helm` | `chart` | Creates/updates a FluxCD `HelmRepository` and patches the `HelmRelease` chart version |
 | `oci` or `helm` | `image` | Patches an existing `HelmRelease` values path with the resolved image tag |
+
+**ArgoCD mode** — updates ArgoCD Application objects:
+
+| `artifact` | Action |
+|-----------|--------|
+| `chart` | Updates `spec.source.repoURL` and `spec.source.targetRevision` on the ArgoCD Application |
+| `image` | Updates the image tag within `spec.source.helm.values` on the ArgoCD Application |
 
 Additional annotations:
 
@@ -195,11 +207,11 @@ Additional annotations:
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--workspace-dir` | `/operator/` | Directory containing operator manifests |
+| `--workspace-dir` | `/operator/` | Directory containing operator manifests and templates |
 | `--kcp-url` | _(auto-detected)_ | kcp API server URL |
 | `--kcp-namespace` | `platform-mesh-system` | Namespace where kcp components run |
 | `--kcp-front-proxy-name` | `frontproxy` | Name of the kcp front-proxy service |
-| `--kcp-front-proxy-port` | `6443` | Port of the kcp front-proxy |
+| `--kcp-front-proxy-port` | `8443` | Port of the kcp front-proxy |
 | `--kcp-root-shard-name` | `root` | Name of the kcp root shard |
 | `--kcp-cluster-admin-secret-name` | `kcp-cluster-admin-client-cert` | Secret with cluster-admin credentials |
 | `--subroutines-deployment-enabled` | `true` | Enable the Deployment subroutine |
@@ -208,15 +220,69 @@ Additional annotations:
 | `--subroutines-provider-secret-enabled` | `true` | Enable the ProviderSecret subroutine |
 | `--subroutines-feature-toggles-enabled` | `false` | Enable the FeatureToggles subroutine |
 | `--subroutines-wait-enabled` | `true` | Enable the Wait subroutine |
+| `--remote-runtime-kubeconfig` | _(none)_ | Kubeconfig for the remote runtime cluster |
+| `--remote-runtime-infra-secret-name` | _(none)_ | Secret name for FluxCD to reach the runtime cluster |
+| `--remote-runtime-infra-secret-key` | _(none)_ | Secret key for FluxCD to reach the runtime cluster |
+| `--remote-infra-kubeconfig` | _(none)_ | Kubeconfig for a remote infra cluster (only needed if Local != Infra) |
+
+### Profile ConfigMap
+
+The operator reads its deployment blueprint from a profile ConfigMap linked to the PlatformMesh resource by naming convention: a PlatformMesh instance named `foo` expects a ConfigMap `foo-profile` in the same namespace (overridable via `spec.profileConfigMap`).
+
+The ConfigMap must contain a `profile.yaml` key with two sections:
+
+- **`infra`** — infrastructure components (cert-manager, traefik, etcd-druid, gateway-api) with enabled state, Helm values, intervals
+- **`components`** — application services with enabled state, chart source, Helm values, dependsOn, syncWave, imageResources
+
+The profile itself is rendered as a Go template with variables derived from `spec.exposure` (e.g., `{{ .baseDomain }}`).
+
+### Configuration and values flow
+
+```
+Profile ConfigMap (components.services.<name>.values)   ← broad/general config
+        │
+        ▼  deep-merge (spec.Values takes precedence)
+PlatformMesh CR (spec.values.services.<name>.values)    ← per-instance overrides
+        │
+        ▼  Go template rendering + variable substitution
+Go Templates → HelmRelease spec.values / ArgoCD Application helm.values (1-to-1 per service)
+```
+
+The profile provides general configuration for all services. The PlatformMesh CR's `spec.values` provides per-instance customization — it is deep-merged on top of the profile. After merging, Go template expressions are resolved and the resulting values are set directly as each service's HelmRelease `spec.values` or ArgoCD Application `spec.source.helm.values`.
+
+### Deployment technologies
+
+The operator supports two deployment technologies, configured per-section in the profile:
+
+- **FluxCD** (`deploymentTechnology: fluxcd`) — creates HelmRelease and OCM Resource objects
+- **ArgoCD** (`deploymentTechnology: argocd`) — creates ArgoCD Application objects with sync-wave ordering
+
+### Remote deployment
+
+Remote deployment is used when the **Runtime** cluster (KCP, OCM) and the **Infra** cluster (FluxCD/ArgoCD) are different clusters.
+
+| Cluster | Role |
+|---------|------|
+| **Local** | Where the operator pod runs |
+| **Runtime** | KCP, OCM Resources, PlatformMesh CR, profile ConfigMap |
+| **Infra** | FluxCD HelmReleases / ArgoCD Applications, OCIRepositories, HelmRepositories |
+
+When using remote deployment:
+- The PlatformMesh resource and profile ConfigMap must be created on the **runtime** cluster — the operator reconciles them remotely.
+- `--remote-runtime-kubeconfig` points the operator's manager to the runtime cluster.
+- `--remote-infra-kubeconfig` is only needed if the operator does not run on the infra cluster (**Local** != **Infra**).
+- HelmReleases gain `spec.kubeConfig.secretRef` pointing to the runtime cluster secret.
+- ArgoCD Applications use `destination.server` to point to the remote runtime cluster.
+
+**Known limitation:** the operator currently supports only a single remote deployment per operator instance.
 
 ### Environment variables
 
 | Variable | Description |
 |----------|-------------|
 | `KUBECONFIG` | Kubeconfig for the cluster hosting the `PlatformMesh` resource |
-| `DEPLOYMENT_KUBECONFIG` | Kubeconfig for the target cluster where components are deployed (enables remote deployment) |
 
-When both variables are unset the operator uses in-cluster credentials for both roles.
+When unset the operator uses in-cluster credentials.
 
 ## Installation
 
@@ -284,16 +350,17 @@ This allows umbrella charts to set shared defaults via `global.*` while individu
 ```mermaid
 graph TD
     PM["PlatformMesh CR"] --> OP["platform-mesh-operator"]
-    OP -->|"deploys"| INFRA["Infra HelmRelease<br/>(cert-manager, Istio, kcp)"]
-    OP -->|"deploys"| COMP["Components HelmRelease<br/>(services)"]
+    OP -->|"renders templates"| INFRA["Infra HelmReleases / ArgoCD Apps<br/>(cert-manager, Istio, kcp)"]
+    OP -->|"renders templates"| COMP["Component HelmReleases / ArgoCD Apps<br/>(services)"]
     OP -->|"configures"| KCP["kcp<br/>(workspaces, API bindings)"]
     OP -->|"generates"| SEC["Provider Secrets<br/>(kubeconfigs)"]
-    OP -->|"uses"| OCM["OCM<br/>(component delivery)"]
+    OP -->|"creates"| OCM["OCM Resources<br/>(component delivery)"]
 ```
 
 - **kcp** — the operator creates the workspace hierarchy and provider connections that form the [control plane](/concepts/control-planes) topology.
-- **OCM (Open Component Model)** — delivers versioned component descriptors that the operator references in HelmRelease and Resource objects.
-- **FluxCD** — the operator creates `HelmRelease` resources managed by the Flux Helm controller.
+- **OCM (Open Component Model)** — delivers versioned component descriptors. The operator creates OCM Resource objects, and the ResourceReconciler syncs resolved artifacts into FluxCD/ArgoCD.
+- **FluxCD** — the operator creates `HelmRelease` and source resources (OCIRepository, HelmRepository, GitRepository) managed by the Flux controllers.
+- **ArgoCD** — alternatively, the operator creates `Application` objects managed by the ArgoCD controller, with sync-wave ordering and automated sync policies.
 - **Istio** — deployed as infrastructure; the operator ensures its sidecar is present before communicating with kcp.
 
 ## Repository

--- a/reference/components/platform-mesh-operator.md
+++ b/reference/components/platform-mesh-operator.md
@@ -261,6 +261,34 @@ The operator supports two deployment technologies, configured per-section in the
 
 Remote deployment is used when the **Runtime** cluster (KCP, OCM) and the **Infra** cluster (FluxCD/ArgoCD) are different clusters.
 
+```mermaid
+graph LR
+    subgraph Local["Local cluster"]
+        OP["platform-mesh-operator"]
+    end
+
+    subgraph Runtime["Runtime cluster"]
+        PM["PlatformMesh CR"]
+        PROF["Profile ConfigMap"]
+        KCP["kcp (RootShard, FrontProxy)"]
+        OCM["OCM Resources"]
+    end
+
+    subgraph Infra["Infra cluster"]
+        FLUX["FluxCD / ArgoCD"]
+        HR["HelmReleases"]
+        OCI["OCIRepositories"]
+        APPS["ArgoCD Applications"]
+    end
+
+    OP -->|"reconciles (remote-runtime-kubeconfig)"| PM
+    OP -->|"reads"| PROF
+    OP -->|"creates OCM Resources"| OCM
+    OP -->|"creates HelmReleases / Apps"| HR
+    OP -->|"creates HelmReleases / Apps"| APPS
+    FLUX -->|"deploys workloads via kubeConfig secret"| Runtime
+```
+
 | Cluster | Role |
 |---------|------|
 | **Local** | Where the operator pod runs |
@@ -369,6 +397,7 @@ graph TD
 
 ## Related
 
+- [Set up remote deployment](/how-to-guides/set-up-remote-deployment.md)
 - [Control planes and workspaces](/concepts/control-planes)
 - [Account model](/concepts/account-model)
 - [Architecture](/concepts/architecture)

--- a/reference/components/platform-mesh-operator.md
+++ b/reference/components/platform-mesh-operator.md
@@ -66,8 +66,8 @@ spec:
 |-------|-------------|
 | `exposure` | External exposure settings: `baseDomain`, `port`, `protocol` |
 | `kcp` | kcp workspace topology: provider connections, extra workspaces, API bindings |
-| `values` | Free-form JSON deep-merged with the profile's `components` section and passed as Helm values to each service |
-| `infraValues` | Free-form JSON merged with the profile's `infra` section |
+| `values` | Free-form JSON merged with the profile's `components` section and passed as Helm values to each service. The merge is recursive — keys present in both the profile and `spec.values` are combined per nested level, and any leaf value in `spec.values` wins over the profile |
+| `infraValues` | Free-form JSON recursively merged with the profile's `infra` section (same merge semantics as `values`) |
 | `ocm` | OCM repository, component name, and reference path for component delivery |
 | `profileConfigMap` | Optional reference to profile ConfigMap (name/namespace). Defaults to `<instance-name>-profile` in the instance namespace |
 | `featureToggles` | List of named feature flags (see [Feature toggles](#feature-toggles)) |
@@ -263,7 +263,7 @@ Remote deployment is used when the **Runtime** cluster (KCP, OCM) and the **Infr
 
 ```mermaid
 graph LR
-    subgraph Local["Local cluster"]
+    subgraph Operator["Operator cluster"]
         OP["platform-mesh-operator"]
     end
 
@@ -291,14 +291,14 @@ graph LR
 
 | Cluster | Role |
 |---------|------|
-| **Local** | Where the operator pod runs |
+| **Operator** | Where the operator pod runs |
 | **Runtime** | KCP, OCM Resources, PlatformMesh CR, profile ConfigMap |
 | **Infra** | FluxCD HelmReleases / ArgoCD Applications, OCIRepositories, HelmRepositories |
 
 When using remote deployment:
 - The PlatformMesh resource and profile ConfigMap must be created on the **runtime** cluster — the operator reconciles them remotely.
 - `--remote-runtime-kubeconfig` points the operator's manager to the runtime cluster.
-- `--remote-infra-kubeconfig` is only needed if the operator does not run on the infra cluster (**Local** != **Infra**).
+- `--remote-infra-kubeconfig` is only needed if the operator does not run on the infra cluster (**Operator** != **Infra**).
 - HelmReleases gain `spec.kubeConfig.secretRef` pointing to the runtime cluster secret.
 - ArgoCD Applications use `destination.server` to point to the remote runtime cluster.
 


### PR DESCRIPTION
**Title:** docs: update platform-mesh-operator reference documentation

**Body:**

## Summary

- Update operator reference to reflect current architecture: Go template rendering replaces the old Helm sub-chart approach
- Add Profile ConfigMap section explaining the linkage between PlatformMesh CR and profile (naming convention or `spec.profileConfigMap`)
- Add Configuration and values flow section: profile provides broad config, `spec.values` provides overrides, merged values are passed 1-to-1 to HelmRelease/ArgoCD Application per service
- Add deployment technologies section (FluxCD / ArgoCD)
- Add remote deployment section: cluster roles, how to enable, effect on downstream resources, known limitation (single remote deployment per operator instance)
- Add remote deployment flags to operator flags table (`--remote-runtime-kubeconfig`, `--remote-infra-kubeconfig`, etc.)
- Update ResourceReconciler docs to cover ArgoCD mode (chart/image artifact handling)
- Update integration diagram to show ArgoCD and template rendering
- Remove outdated references (`DEPLOYMENT_KUBECONFIG` env var, old Helm chart names)

## Test plan

- [x] Verify docs site builds without errors
- [ ] Review rendered page for formatting and link correctness
- [ ] Cross-reference with platform-mesh-operator README for consistency

refers to https://github.com/platform-mesh/helm-charts/issues/1607