### PR TITLE
fix: stabilize scrollbar gutter to stop layout shifting between pages

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -29,6 +29,48 @@
   max-width: 1168px !important;
 }
 
+/* Stabilise the scrollbar gutter.
+
+   The whole page scrolls on <html>, and the entire layout (navbar + doc) is
+   centered within --vp-layout-max-width. Pages whose content overflows show a
+   vertical scrollbar; pages that fit do not. On browsers that reserve space for
+   classic scrollbars (e.g. macOS "Show scroll bars: Always", common on external
+   monitors), that ~15px width change re-centers the layout, so the logo, nav and
+   content column visibly shift left/right when navigating between a scrolling and
+   a non-scrolling page (e.g. /reference/ vs /concepts/). Reserving the gutter on
+   every page keeps the layout fixed. No-op where scrollbars are overlays. */
+html {
+  scrollbar-gutter: stable;
+}
+
+/* Keep internal (sidebar) pages gutter-aware so the navbar and content line up
+   with the home page.
+
+   VitePress positions the sidebar-page navbar and main content with 100vw-based
+   padding, e.g. padding-right: calc((100vw - var(--vp-layout-max-width)) / 2).
+   100vw includes the scrollbar gutter reserved above, but the home page navbar
+   centers via 100% (gutter-aware, margin: 0 auto). On wide screens that half-
+   gutter difference makes the navbar's right-hand items (search, version
+   selector, social links) and the content/outline column sit ~half a scrollbar
+   width off from the home page — so the version selector visibly shifts when
+   navigating Home <-> any menu page.
+
+   Recomputing the same offsets with 100% instead of 100vw makes the internal
+   pages gutter-aware too, so the home navbar, the internal-page navbars and the
+   content/outline column all align at every width. max() floors the values so
+   narrow viewports fall back to VitePress defaults. Revisit if VitePress changes
+   these paddings upstream. */
+@media (min-width: 1440px) {
+  .VPNavBar.has-sidebar .content {
+    padding-right: max(32px, calc((100% - var(--vp-layout-max-width)) / 2 + 32px)) !important;
+  }
+
+  .VPContent.has-sidebar {
+    padding-right: max(0px, calc((100% - var(--vp-layout-max-width)) / 2)) !important;
+    padding-left: calc(max(0px, (100% - var(--vp-layout-max-width)) / 2) + var(--vp-sidebar-width)) !important;
+  }
+}
+
 
 @media (min-width: 640px) {
     :root {


### PR DESCRIPTION
## What

Fixes the content and navbar shifting horizontally ("jumping") by a few millimetres when navigating between documentation pages.

## Root causes

Two distinct causes, both surfacing on browsers that **reserve** scrollbar space (e.g. macOS "Show scroll bars: Always", common on external/ultra-wide monitors):

1. **Page-to-page shift (all pages).** The whole page scrolls on `<html>` and the layout is centered within `--vp-layout-max-width`. Pages whose content overflows show a vertical scrollbar; pages that fit don't. That ~15px width change re-centers everything, so the logo, nav and content column shift between a scrolling and a non-scrolling page (e.g. `/reference/` vs `/concepts/`).

2. **Home ↔ menu-page shift (version selector / right-hand nav).** VitePress positions sidebar-page navbars and content with `100vw`-based padding (gutter-*inclusive*), while the home navbar centers via `100%` (gutter-*aware*). With the gutter reserved, the two differ by half a scrollbar width, so the version selector and right nav items jump when moving between the home page and any menu page.

## Fix

All in `.vitepress/theme/custom.css`:

- `html { scrollbar-gutter: stable }` — reserve the gutter on every page so it never toggles.
- A `@media (min-width: 1440px)` block recomputing the sidebar-page navbar/content paddings with `100%` instead of `100vw`, so internal pages are gutter-aware and line up with the home page. `max()` floors the values so narrow viewports fall back to VitePress defaults.

No-op on overlay-scrollbar systems (which never had the jump).

## Verification

Measured with headless Chrome against the dev server:

- All 71 doc pages + home share an identical logo position — no page-to-page shift.
- Version selector / GitHub icon / outline-column right edges align across home + all six menu pages at **1920px and 3440px** (ultra-wide).
- The navbar now also aligns with each doc page's "On this page" outline; incidentally corrects a pre-existing misalignment in the 1440–1536px range.
- Full 85-route crawl: 0 missing/404; redirect stubs serve 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
