### PR TITLE
Add information about contributing to tutorials

### DIFF
--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -17,6 +17,10 @@ Set up a local Platform Mesh environment first: [Set up Platform Mesh locally](/
 
 Use [How-to guides](/how-to-guides/) for specific local tasks, or read [Concepts](/concepts/) to understand the architecture behind what you just ran.
 
+## Community and support
+
+Platform Mesh welcomes contributions from the community. The project's [contributing guide](https://github.com/platform-mesh/.github/blob/main/CONTRIBUTING.md) covers how to find work, open pull requests, and review changes. If you have any questions or want to leave feedback, please reach out via [our community channels](/community/).
+
 ## Related sections
 
 - [How-to guides](/how-to-guides/) - task-focused operational instructions.


### PR DESCRIPTION
OpenSSF Best Practices require:

> The project website MUST provide information on how to: obtain, provide feedback (as bug reports or enhancements), and contribute to the software.

As we already link to this page in the assessment, I added the required information there.

cc @mirzakopic 