### PR TITLE
docs: add community call schedule and join link (release-0.3)

### DIFF
--- a/community/calls.md
+++ b/community/calls.md
@@ -2,20 +2,16 @@
 
 Platform Mesh community calls are open meetings for project discussions, demos, and Q&A.
 
-::: info
-The first community call has not yet taken place. This page is updated with the schedule and joining instructions once announced.
-:::
-
 ## Schedule
 
-TBD.
+The community call runs every two weeks on Tuesday at 16:00 CET (15:00 UTC during standard time, 14:00 UTC during daylight saving).
+
+Subscribe to the [Platform Mesh public calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/platform-mesh) to see upcoming meetings in your local time.
 
 ## How to join
 
-TBD.
+[Join the community call on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/93538459120?password=6fe4d0da-3a68-4b4d-9f65-7330007ed8cc).
 
-## Agenda and notes
-
-TBD.
+Meeting ID: `93538459120`.
 
 Recorded talks and presentations are listed under [Talks](./talks.md).


### PR DESCRIPTION
## Summary
- Backport of #215 to `release-0.3` so https://platform-mesh.io/release-0.3/community/ shows the same content.
- Same edit: bi-weekly Tuesday schedule, LFX public calendar link, Zoom join link, drop empty agenda section.

## Test plan
- [x] `npm run build` succeeds on the main-branch sibling PR (#215); identical file change here
- [x] Verified locally on `npm run dev` at `/community/calls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)